### PR TITLE
Update mcp.json examples to use jsonc instead of json fence

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To integrate the Log Analyzer MCP server with a client application (like Cursor)
 
 **Example Client Configuration (e.g., in `.cursor/mcp.json`):**
 
-```json
+```jsonc
 {
   "mcpServers": {
     "log_analyzer_mcp_server_prod": {

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -171,7 +171,7 @@ The `.cursor/mcp.json` file defines configurations for running the MCP server in
 - **Purpose:** For testing the packaged version of the server, usually installed from TestPyPI. This helps verify that packaging, dependencies, and entry points work correctly.
 - **Configuration (`.cursor/mcp.json` snippet):**
 
-    ```json
+    ```jsonc
     "log_analyzer_mcp_server_test": {
       "command": "uvx", // uvx is a tool to run python executables from venvs
       "args": [
@@ -195,7 +195,7 @@ The `.cursor/mcp.json` file defines configurations for running the MCP server in
 - **Purpose:** For running the stable, released version of the MCP server, typically installed from PyPI.
 - **Configuration (`.cursor/mcp.json` snippet):**
 
-    ```json
+    ```jsonc
     "log_analyzer_mcp_server_prod": {
       "command": "uvx",
       "args": [

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -54,7 +54,7 @@ The recommended way to run the MCP server in a production-like or stable integra
 
 This snippet shows how you might configure Cursor (or a similar client) to use the `log-analyzer-mcp` package installed from PyPI. The `uvx` command is a utility to run Python executables from dynamically created virtual environments.
 
-```json
+```jsonc
 {
   "mcpServers": {
     "log_analyzer_mcp_server_prod": {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

New Features # (issue)

- Use jsonc instead of json markdown classifier for commented json blocks

Fixes # (issue)

- rendering of mcp.json examples

## Type of change

Please delete options that are not relevant.

- [x] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- n/a

## Checklist

- [x] I have made corresponding changes to the documentation
