### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 [![codecov](https://codecov.io/gh/djm81/log_analyzer_mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/djm81/log_analyzer_mcp)
 [![PyPI - Version](https://img.shields.io/pypi/v/log-analyzer-mcp?color=blue)](https://pypi.org/project/log-analyzer-mcp)
 
+<a href="https://glama.ai/mcp/servers/@djm81/log_analyzer_mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@djm81/log_analyzer_mcp/badge" alt="Log Analyzer MCP server" />
+</a>
+
 ## Overview: Analyze Logs with Ease
 
 **Log Analyzer MCP** is a powerful Python-based toolkit designed to streamline the way you interact with log files. Whether you're debugging complex applications, monitoring test runs, or simply trying to make sense of verbose log outputs, this tool provides both a Command-Line Interface (CLI) and a Model-Context-Protocol (MCP) server to help you find the insights you need, quickly and efficiently.


### PR DESCRIPTION
This PR adds a badge for the [Log Analyzer MCP](https://glama.ai/mcp/servers/@djm81/log_analyzer_mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@djm81/log_analyzer_mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@djm81/log_analyzer_mcp/badge" alt="Log Analyzer MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.